### PR TITLE
Feature/add 404

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -19,8 +19,11 @@ class EventController extends Controller
 	public function detail(Request $request,$event_code)
 	{
 		$user = Auth::User();
-
-		$capacity = Event::FindCode($event_code)->first()->capacity;
+		try{	//イベントが見つからなかった時のエラー回避処理
+			$capacity = Event::FindCode($event_code)->first()->capacity;
+		}catch(\Exception $e){
+			return view('errors/404');
+		}
 
 		$data['event'] = Event::FindCode($event_code)->with('organizer')->first();
 	

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -54,6 +54,10 @@ class UserController extends Controller
 	public function userpageJoin(Request $request, $userCode) {
 		if(Auth::check() && Auth::user()->code === $userCode) return redirect()->route('user-mypage-join');
 		$user = User::findCode($userCode);
+		if(is_null($user)){	//ユーザーが見つからなかった時のエラー回避処理
+			return view('errors/404');
+		}
+
 		$data['user'] = $user;
 		$data['events'] = $user->joined_events()->paginate(10);		
         return view('user/user-userpage-join', $data);    
@@ -62,6 +66,9 @@ class UserController extends Controller
 	public function userpageHold(Request $request, $userCode) {
 		if(Auth::check() && Auth::user()->code === $userCode) return redirect()->route('user-mypage-hold');
 		$user = User::findCode($userCode);
+		if(is_null($user)){	//ユーザーが見つからなかった時のエラー回避処理
+			return view('errors/404');
+		}
 		$data['user'] = $user;
 		$data['events'] = $user->hold_events()->paginate(10);
         return view('user/user-userpage-hold', $data);    

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,13 @@
+@extends('errors.err-layout')
+
+@section('err-title')
+お探しのページは見つかりません。<br>
+404: Not Found
+@endsection
+
+@section('err-wording')
+<p>
+お探しのページは一時的にアクセスができない状況にあるか、移動もしくは削除された可能性があります。 
+また、URLにタイプミスなどがないか再度ご確認ください。
+</p>
+@endsection


### PR DESCRIPTION
404エラーを表示できるようにしました。
/user/hogeや/event/fugaなどの存在しないイベントIDやユーザーIDにアクセスした時に、
DBに存在しない系の内容のLaravelエラーが表示されていた代わりに、404ページを表示させるように変更(利用者にLaravelエラーを見せないため)

存在しないURLを入力した際に、laravelのデフォルトで404.blade.phpにルーティングされた時
ヘッダーのグーグルボタンがログイン中でも出てしまうバグがある（直し方現在不明で放置）
