### PR TITLE
検索結果の表示バグ修正 #180

### DIFF
--- a/resources/assets/js/components/event-item.vue
+++ b/resources/assets/js/components/event-item.vue
@@ -98,12 +98,8 @@
                 let opendate = this.dateFormat(date)
                 let today = new Date();
 
-                var dateZellFill = function(number) {
-                    return ("0" + number).substr(-2);
-                }
-
-                today = dateZellFill(today.getFullYear()) + '' + dateZellFill((today.getMonth() + 1)) + '' + dateZellFill(today.getDate())
-
+                today = today.getFullYear() + '-' + (today.getMonth() + 1) + '-' + today.getDate()
+                
                 if (today < opendate) {
                     str = 'before'
                 }　


### PR DESCRIPTION
# 概要
Issue #180 の検索結果のバグを修正しました。

# 改修対象
JS 上の比較用処理（ formatStates ）を修正。
与えられた文字列と内部で生成した比較用文字列のフォーマットが異なっていたため、全てtrueとなり、"開催前"と表示されていた。